### PR TITLE
Improve login experience and project loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,4 +59,4 @@ The application expects data files (Excel or CSV) with the following columns:
 
 ## License
 
-MIT License 
+MIT License

--- a/templates/index.html
+++ b/templates/index.html
@@ -174,6 +174,10 @@
                     projectSection.classList.remove('hidden');
                 } catch (err) {
                     console.error('Error loading projects', err);
+                    if (err.response && err.response.status === 401) {
+                        localStorage.removeItem('authToken');
+                        window.location.href = '/login';
+                    }
                 }
             }
 

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -30,12 +30,14 @@
         signupForm.addEventListener('submit', async e => {
             e.preventDefault();
             try {
-                await axios.post('/signup', {
-                    username: document.getElementById('signup-username').value,
-                    password: document.getElementById('signup-password').value
-                });
-                authStatus.textContent = 'Signup successful. You can now login.';
-                authStatus.className = 'text-green-600 text-sm text-center';
+                const username = document.getElementById('signup-username').value;
+                const password = document.getElementById('signup-password').value;
+
+                await axios.post('/signup', { username, password });
+
+                const loginRes = await axios.post('/login', { username, password });
+                localStorage.setItem('authToken', loginRes.data.token);
+                window.location.href = '/dashboard';
             } catch (err) {
                 authStatus.textContent = 'Signup error: ' + (err.response?.data?.detail || err.message);
                 authStatus.className = 'text-red-600 text-sm text-center';


### PR DESCRIPTION
## Summary
- auto-login user after signup and redirect to dashboard
- redirect to login if project list retrieval fails with 401
- ensure README ends with newline

## Testing
- `python -m py_compile app.py database.py graph_analyser.py data_loader.py`