### PR TITLE
Link seasonal & advanced pages with stored project files

### DIFF
--- a/database.py
+++ b/database.py
@@ -342,6 +342,35 @@ class Database:
         cursor.execute("SELECT id, name FROM projects WHERE user_id = ?", (user_id,))
         rows = cursor.fetchall()
         return [{"id": row[0], "name": row[1]} for row in rows]
+
+    def get_project_files(self, project_id: int) -> List[Dict[str, Any]]:
+        """Return files associated with a project."""
+        cursor = self.conn.cursor()
+        cursor.execute(
+            "SELECT id, filename, upload_time FROM files WHERE project_id = ?",
+            (project_id,),
+        )
+        rows = cursor.fetchall()
+        return [
+            {
+                "id": row[0],
+                "filename": row[1],
+                "upload_time": row[2],
+            }
+            for row in rows
+        ]
+
+    def get_file_info(self, file_id: int) -> Optional[Dict[str, Any]]:
+        """Get basic information about a file."""
+        cursor = self.conn.cursor()
+        cursor.execute(
+            "SELECT id, filename, project_id FROM files WHERE id = ?",
+            (file_id,),
+        )
+        row = cursor.fetchone()
+        if row:
+            return {"id": row[0], "filename": row[1], "project_id": row[2]}
+        return None
     
     def close(self):
         """Close the database connection."""

--- a/templates/advanced.html
+++ b/templates/advanced.html
@@ -74,6 +74,8 @@
             <div class="col-md-4">
                 <label class="form-label">Select Project</label>
                 <select id="project-select" class="form-select mb-2"></select>
+                <label class="form-label mt-2">Select File</label>
+                <select id="file-select" class="form-select mb-2"></select>
                 <div class="d-flex">
                     <input type="text" id="new-project-name" class="form-control me-2" placeholder="New project name">
                     <button id="create-project" class="btn btn-success">Create</button>
@@ -131,7 +133,8 @@
             const authStatus = document.getElementById('auth-status');
             const signupForm = document.getElementById('signup-form');
             const loginForm = document.getElementById('login-form');
-            const projectSelect = document.getElementById('project-select');
+           const projectSelect = document.getElementById('project-select');
+            const fileSelect = document.getElementById('file-select');
             const createProjectBtn = document.getElementById('create-project');
             const newProjectName = document.getElementById('new-project-name');
             const fileInput = document.getElementById('file-input');
@@ -152,6 +155,41 @@
                     opt.textContent = p.name;
                     projectSelect.appendChild(opt);
                 });
+                if (data.projects.length > 0) {
+                    await loadFiles();
+                }
+            }
+
+            async function loadFiles() {
+                const token = localStorage.getItem('authToken');
+                if (!token) return;
+                const pid = projectSelect.value;
+                if (!pid) return;
+                const res = await fetch(`/projects/${pid}/files`, { headers: { 'Authorization': `Bearer ${token}` } });
+                if (!res.ok) return;
+                const data = await res.json();
+                fileSelect.innerHTML = '';
+                data.files.forEach(f => {
+                    const opt = document.createElement('option');
+                    opt.value = f.id;
+                    opt.textContent = f.filename;
+                    fileSelect.appendChild(opt);
+                });
+                if (data.files.length > 0) {
+                    fileSelect.value = data.files[0].id;
+                    currentFileId = data.files[0].id;
+                    await loadExistingAnalysis();
+                }
+            }
+
+            async function loadExistingAnalysis() {
+                if (!currentFileId) return;
+                const token = localStorage.getItem('authToken');
+                const res = await fetch(`/files/${currentFileId}/latest-analysis`, { headers: { 'Authorization': `Bearer ${token}` } });
+                if (!res.ok) return;
+                const data = await res.json();
+                await runBasicAnalysis(data.mapping);
+                await performAdvancedAnalysis();
             }
 
             if (signupForm) {
@@ -290,6 +328,17 @@
 
             if (fileInput) {
                 fileInput.addEventListener('change', uploadAndAnalyse);
+            }
+
+            if (projectSelect) {
+                projectSelect.addEventListener('change', loadFiles);
+            }
+
+            if (fileSelect) {
+                fileSelect.addEventListener('change', () => {
+                    currentFileId = fileSelect.value;
+                    loadExistingAnalysis();
+                });
             }
 
             if (localStorage.getItem('authToken')) {

--- a/templates/seasonal.html
+++ b/templates/seasonal.html
@@ -74,6 +74,8 @@
             <div class="col-md-4">
                 <label class="form-label">Select Project</label>
                 <select id="project-select" class="form-select mb-2"></select>
+                <label class="form-label mt-2">Select File</label>
+                <select id="file-select" class="form-select mb-2"></select>
                 <div class="d-flex">
                     <input type="text" id="new-project-name" class="form-control me-2" placeholder="New project name">
                     <button id="create-project" class="btn btn-success">Create</button>
@@ -124,7 +126,8 @@
             const authStatus = document.getElementById('auth-status');
             const signupForm = document.getElementById('signup-form');
             const loginForm = document.getElementById('login-form');
-            const projectSelect = document.getElementById('project-select');
+           const projectSelect = document.getElementById('project-select');
+            const fileSelect = document.getElementById('file-select');
             const createProjectBtn = document.getElementById('create-project');
             const newProjectName = document.getElementById('new-project-name');
             const fileInput = document.getElementById('file-input');
@@ -145,6 +148,41 @@
                     opt.textContent = p.name;
                     projectSelect.appendChild(opt);
                 });
+                if (data.projects.length > 0) {
+                    await loadFiles();
+                }
+            }
+
+            async function loadFiles() {
+                const token = localStorage.getItem('authToken');
+                if (!token) return;
+                const pid = projectSelect.value;
+                if (!pid) return;
+                const res = await fetch(`/projects/${pid}/files`, { headers: { 'Authorization': `Bearer ${token}` } });
+                if (!res.ok) return;
+                const data = await res.json();
+                fileSelect.innerHTML = '';
+                data.files.forEach(f => {
+                    const opt = document.createElement('option');
+                    opt.value = f.id;
+                    opt.textContent = f.filename;
+                    fileSelect.appendChild(opt);
+                });
+                if (data.files.length > 0) {
+                    fileSelect.value = data.files[0].id;
+                    currentFileId = data.files[0].id;
+                    await loadExistingAnalysis();
+                }
+            }
+
+            async function loadExistingAnalysis() {
+                if (!currentFileId) return;
+                const token = localStorage.getItem('authToken');
+                const res = await fetch(`/files/${currentFileId}/latest-analysis`, { headers: { 'Authorization': `Bearer ${token}` } });
+                if (!res.ok) return;
+                const data = await res.json();
+                await runBasicAnalysis(data.mapping);
+                await performSeasonalAnalysis();
             }
 
             if (signupForm) {
@@ -297,6 +335,17 @@
 
             if (fileInput) {
                 fileInput.addEventListener('change', uploadAndAnalyse);
+            }
+
+            if (projectSelect) {
+                projectSelect.addEventListener('change', loadFiles);
+            }
+
+            if (fileSelect) {
+                fileSelect.addEventListener('change', () => {
+                    currentFileId = fileSelect.value;
+                    loadExistingAnalysis();
+                });
             }
 
             if (localStorage.getItem('authToken')) {


### PR DESCRIPTION
## Summary
- track uploaded project files via `get_project_files` and `get_file_info`
- expose API endpoints to list project files and retrieve latest mapping
- allow selecting existing files on seasonal/advanced pages
- auto-load prior analyses when a file is chosen

## Testing
- `python -m py_compile app.py database.py data_loader.py graph_analyser.py`