### PR TITLE
Add summary output for correlation analysis

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -1,6 +1,7 @@
 import logging
 from typing import List
 from pathlib import Path
+import json
 
 import pandas as pd
 import statsmodels.api as sm
@@ -65,6 +66,20 @@ def analyze_movement_rain_temp(output_dir: Path = Path("analysis_outputs")) -> N
     logger.info("Computing partial correlations...")
     pcorrs = compute_partial_correlations(df)
     logger.info("Partial correlations:\n%s", pcorrs)
+
+    summary = {
+        "regression": {
+            "coefficients": model.params.to_dict(),
+            "p_values": model.pvalues.to_dict(),
+            "r_squared": model.rsquared,
+        },
+        "partial_correlations": {
+            "rainfall_vs_movement_given_temp": pcorrs.iloc[0].to_dict(),
+            "temperature_vs_movement_given_rain": pcorrs.iloc[1].to_dict(),
+        },
+    }
+    with open(output_dir / "summary.json", "w") as f:
+        json.dump(summary, f, indent=2, default=float)
 
     logger.info("Generating plots...")
     pd.plotting.scatter_matrix(df[['movement_mm', 'rainfall_mm', 'temperature_C']], diagonal='kde')

--- a/app.py
+++ b/app.py
@@ -1210,6 +1210,17 @@ async def correlation_page(request: Request):
     """Serve the correlation analysis page"""
     return templates.TemplateResponse("correlation.html", {"request": request})
 
+
+@app.get("/correlation-summary")
+async def correlation_summary():
+    """Return regression and correlation summary as JSON."""
+    summary_file = ANALYSIS_OUTPUT_DIR / "summary.json"
+    if not summary_file.exists():
+        raise HTTPException(status_code=404, detail="Summary not available")
+    with summary_file.open() as f:
+        data = json.load(f)
+    return JSONResponse(data)
+
 @app.post("/analyse/seasonal")
 async def seasonal_analysis(data: dict):
     """Perform seasonal analysis on the stored data"""

--- a/templates/correlation.html
+++ b/templates/correlation.html
@@ -29,6 +29,10 @@
     <div class="container mx-auto px-4 py-8">
         <h1 class="text-3xl font-bold mb-6">Correlation Analysis</h1>
         <p class="mb-4 text-gray-700">These plots show the relationship between structural movement, rainfall and temperature based on example data analysed at server startup.</p>
+        <div id="summary" class="mb-8">
+            <h2 class="text-xl font-semibold mb-2">Analysis Summary</h2>
+            <pre id="summary-content" class="bg-white p-4 rounded shadow whitespace-pre-wrap"></pre>
+        </div>
         <div class="space-y-8">
             <div>
                 <h2 class="text-xl font-semibold mb-2">Scatter Matrix</h2>
@@ -56,6 +60,14 @@
                     window.location.href = '/login';
                 });
             }
+
+            axios.get('/correlation-summary')
+                .then(res => {
+                    document.getElementById('summary-content').textContent = JSON.stringify(res.data, null, 2);
+                })
+                .catch(() => {
+                    document.getElementById('summary-content').textContent = 'Summary not available';
+                });
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- save regression results and partial correlations to `summary.json`
- expose a new `/correlation-summary` API returning the summary
- display the summary on the correlation analysis page

## Testing
- `python -m py_compile $(git ls-files '*.py')`