### PR TITLE
Adjust rolling correlation threshold

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -58,7 +58,7 @@ def compute_rolling_correlation(df: pd.DataFrame, window: int = 30) -> pd.DataFr
     return pd.DataFrame(records)
 
 
-def first_significant_date(rcorr: pd.DataFrame, r_thresh: float = 0.5, p_thresh: float = 0.05, consecutive: int = 1) -> Optional[pd.Timestamp]:
+def first_significant_date(rcorr: pd.DataFrame, r_thresh: float = 0.4, p_thresh: float = 0.05, consecutive: int = 1) -> Optional[pd.Timestamp]:
     """Find the first date where correlation exceeds thresholds."""
     mask = (rcorr['r'].abs() >= r_thresh) & (rcorr['p'] < p_thresh)
     if consecutive > 1:
@@ -103,7 +103,7 @@ def analyze_movement_rain_temp(output_dir: Path = Path("analysis_outputs")) -> N
 
     logger.info("Computing rolling correlation...")
     rcorr = compute_rolling_correlation(df, window=30)
-    first_date = first_significant_date(rcorr)
+    first_date = first_significant_date(rcorr, r_thresh=0.4)
     if not rcorr.empty:
         plt.plot(rcorr['timestamp'], rcorr['r'])
         plt.axhline(0, color='black', linewidth=0.5)
@@ -129,7 +129,7 @@ def analyze_movement_rain_temp(output_dir: Path = Path("analysis_outputs")) -> N
         },
         "rolling_correlation": {
             "window_days": 30,
-            "threshold_r": 0.5,
+            "threshold_r": 0.4,
             "threshold_p": 0.05,
             "first_significant_date": first_date.strftime('%Y-%m-%d') if first_date is not None else None,
         },

--- a/templates/correlation.html
+++ b/templates/correlation.html
@@ -54,7 +54,7 @@
                 <ol class="list-decimal list-inside text-gray-700 space-y-1">
                     <li>Align both series on a daily index without gaps.</li>
                     <li>Compute the 30-day rolling correlation and its p-value.</li>
-                    <li>Locate the earliest window where |r| ≥ 0.5 and p &lt; 0.05 (optionally requiring persistence).</li>
+                    <li>Locate the earliest window where |r| ≥ 0.4 and p &lt; 0.05 (optionally requiring persistence).</li>
                 </ol>
                 <p class="text-gray-700 mt-2">The detected date, if any, is included in the summary above.</p>
             </div>


### PR DESCRIPTION
## Summary
- lower threshold for rolling correlation onset detection to `0.4`
- update summary output and documentation

## Testing
- `python -m py_compile $(git ls-files '*.py')`