### PR TITLE
Fix cross-correlation display

### DIFF
--- a/templates/correlation.html
+++ b/templates/correlation.html
@@ -37,19 +37,19 @@
         <div class="space-y-8">
             <div>
                 <h2 class="text-xl font-semibold mb-2">Scatter Matrix</h2>
-                <div id="scatter-matrix" class="mx-auto border rounded shadow" style="height: 500px;"></div>
-                <p class="text-gray-700 mt-2">Each panel compares two variables while the diagonal shows their individual distributions. Look for elongated point clouds or straight-line trends &ndash; these indicate a strong linear relationship between the corresponding variables.</p>
-            </div>
-            <div>
-                <h2 class="text-xl font-semibold mb-2">Rainfall Cross-Correlation</h2>
-                <div id="rainfall-ccf" class="mx-auto border rounded shadow" style="height: 400px;"></div>
-                <p class="text-gray-700 mt-2">Bars show how well rainfall aligns with later movement. A prominent positive bar at a specific lag means movement tends to follow rainfall after that many days.</p>
-            </div>
-            <div>
-                <h2 class="text-xl font-semibold mb-2">Temperature Cross-Correlation</h2>
-                <div id="temperature-ccf" class="mx-auto border rounded shadow" style="height: 400px;"></div>
-                <p class="text-gray-700 mt-2">The bars reveal whether changes in temperature precede or lag behind movement. Peaks near zero lag indicate a near-immediate relationship.</p>
-            </div>
+        <div id="scatter-matrix" class="mx-auto border rounded shadow" style="height: 500px;"></div>
+        <p class="text-gray-700 mt-2">Each panel compares two variables while the diagonal shows their individual distributions. Look for elongated point clouds or straight-line trends &ndash; these indicate a strong linear relationship between the corresponding variables.</p>
+    </div>
+    <div>
+        <h2 class="text-xl font-semibold mb-2">Rainfall Cross-Correlation</h2>
+        <img src="/analysis_outputs/rainfall_ccf.png" alt="Rainfall cross correlation" class="mx-auto border rounded shadow" style="max-height: 400px;">
+        <p class="text-gray-700 mt-2">Bars show how well rainfall aligns with later movement. A prominent positive bar at a specific lag means movement tends to follow rainfall after that many days.</p>
+    </div>
+    <div>
+        <h2 class="text-xl font-semibold mb-2">Temperature Cross-Correlation</h2>
+        <img src="/analysis_outputs/temperature_ccf.png" alt="Temperature cross correlation" class="mx-auto border rounded shadow" style="max-height: 400px;">
+        <p class="text-gray-700 mt-2">The bars reveal whether changes in temperature precede or lag behind movement. Peaks near zero lag indicate a near-immediate relationship.</p>
+    </div>
             <div>
                 <h2 class="text-xl font-semibold mb-2">Rolling Correlation Onset Detection</h2>
                 <img src="/analysis_outputs/rolling_correlation.png" alt="Rolling correlation" class="mx-auto border rounded shadow mb-4">
@@ -101,23 +101,6 @@
                     Plotly.newPlot('scatter-matrix', [{type: 'splom', dimensions, marker: {size: 5}}], {title: 'Scatter Matrix'});
                 });
 
-            // Rainfall CCF
-            axios.get('/analysis_outputs/rainfall_ccf.json')
-                .then(res => {
-                    const values = res.data;
-                    const trace = {x: values.map((_, i) => i), y: values, type: 'bar'};
-                    const layout = {title: 'Rainfall → Movement CCF', xaxis: {title: 'Lag (days)'}, yaxis: {title: 'Correlation'}};
-                    Plotly.newPlot('rainfall-ccf', [trace], layout);
-                });
-
-            // Temperature CCF
-            axios.get('/analysis_outputs/temperature_ccf.json')
-                .then(res => {
-                    const values = res.data;
-                    const trace = {x: values.map((_, i) => i), y: values, type: 'bar'};
-                    const layout = {title: 'Temperature → Movement CCF', xaxis: {title: 'Lag (days)'}, yaxis: {title: 'Correlation'}};
-                    Plotly.newPlot('temperature-ccf', [trace], layout);
-                });
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- use PNG fallback for rainfall and temperature CCF

## Testing
- `python -m py_compile $(git ls-files '*.py')`