### PR TITLE
Switch rolling correlation to 10‑day window

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -44,7 +44,7 @@ def compute_partial_correlations(df: pd.DataFrame) -> pd.DataFrame:
     return pd.concat([p1, p2], axis=0)
 
 
-def compute_rolling_correlation(df: pd.DataFrame, window: int = 30) -> pd.DataFrame:
+def compute_rolling_correlation(df: pd.DataFrame, window: int = 10) -> pd.DataFrame:
     """Return rolling correlation and p-values between movement and rainfall."""
     records = []
     for i in range(window - 1, len(df)):
@@ -102,14 +102,14 @@ def analyze_movement_rain_temp(output_dir: Path = Path("analysis_outputs")) -> N
     logger.info("Partial correlations:\n%s", pcorrs)
 
     logger.info("Computing rolling correlation...")
-    rcorr = compute_rolling_correlation(df, window=30)
+    rcorr = compute_rolling_correlation(df, window=10)
     first_date = first_significant_date(rcorr, r_thresh=0.4)
     if not rcorr.empty:
         plt.plot(rcorr['timestamp'], rcorr['r'])
         plt.axhline(0, color='black', linewidth=0.5)
         plt.xlabel('Date')
         plt.ylabel('Rolling Pearson r')
-        plt.title('Rolling 30-day correlation')
+        plt.title('Rolling 10-day correlation')
         plt.xticks(rotation=45)
         plt.tight_layout()
         plt.savefig(output_dir / 'rolling_correlation.png')
@@ -128,7 +128,7 @@ def analyze_movement_rain_temp(output_dir: Path = Path("analysis_outputs")) -> N
             "temperature_vs_movement_given_rain": pcorrs.iloc[1].to_dict(),
         },
         "rolling_correlation": {
-            "window_days": 30,
+            "window_days": 10,
             "threshold_r": 0.4,
             "threshold_p": 0.05,
             "first_significant_date": first_date.strftime('%Y-%m-%d') if first_date is not None else None,

--- a/templates/correlation.html
+++ b/templates/correlation.html
@@ -56,10 +56,10 @@
                 <p class="text-gray-700 mb-2">A rolling Pearson correlation is computed between de-seasonalized movement and the 7-day cumulative rainfall series. When the correlation magnitude first exceeds a chosen threshold and is statistically significant, the corresponding date indicates when movement starts responding to rainfall.</p>
                 <ol class="list-decimal list-inside text-gray-700 space-y-1">
                     <li>Align both series on a daily index without gaps.</li>
-                    <li>Compute the 30-day rolling correlation and its p-value.</li>
+                    <li>Compute the 10-day rolling correlation and its p-value.</li>
                     <li>Locate the earliest window where |r| ≥ 0.4 and p &lt; 0.05 (optionally requiring persistence).</li>
                 </ol>
-                <p class="text-gray-700 mt-2">The detected date, if any, is included in the summary above.</p>
+                <p class="text-gray-700 mt-2">Detected onset date: <span id="detected-date">Loading...</span></p>
             </div>
         </div>
     </div>
@@ -79,9 +79,11 @@
             axios.get('/correlation-summary')
                 .then(res => {
                     document.getElementById('summary-content').textContent = JSON.stringify(res.data, null, 2);
+                    document.getElementById('detected-date').textContent = res.data.rolling_correlation.first_significant_date || 'None';
                 })
                 .catch(() => {
                     document.getElementById('summary-content').textContent = 'Summary not available';
+                    document.getElementById('detected-date').textContent = 'None';
                 });
 
             // Load merged data for scatter matrix


### PR DESCRIPTION
## Summary
- shorten rolling correlation window from 30 to 10 days
- display the detected onset date on the correlation page

## Testing
- `grep -R "10-day" -n`