### PR TITLE
Add dynamic lag correlation with interactive plot

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -44,8 +44,16 @@ def compute_partial_correlations(df: pd.DataFrame) -> pd.DataFrame:
     return pd.concat([p1, p2], axis=0)
 
 
-def compute_rolling_correlation(df: pd.DataFrame, window: int = 10) -> pd.DataFrame:
-    """Return rolling correlation and p-values between movement and rainfall."""
+def compute_rolling_correlation(df: pd.DataFrame, window: int = 14) -> pd.DataFrame:
+    """Return rolling correlation and p-values between movement and rainfall.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame containing ``movement_mm`` and ``rainfall_mm`` columns.
+    window : int, optional
+        Size of the rolling window in days. Defaults to ``14``.
+    """
     records = []
     for i in range(window - 1, len(df)):
         sub = df.iloc[i - window + 1 : i + 1]
@@ -55,6 +63,51 @@ def compute_rolling_correlation(df: pd.DataFrame, window: int = 10) -> pd.DataFr
             'r': float(r),
             'p': float(p),
         })
+    return pd.DataFrame(records)
+
+
+def compute_dynamic_lag_correlation(
+    df: pd.DataFrame, window: int = 30, max_lag: int = 14
+) -> pd.DataFrame:
+    """Return lag that maximizes correlation within sliding windows.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame containing ``movement_mm`` and ``rainfall_mm`` columns.
+    window : int, optional
+        Size of the sliding window in days. Defaults to ``30``.
+    max_lag : int, optional
+        Maximum lag to test in either direction. Defaults to ``14``.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with columns ``timestamp``, ``best_r`` and ``best_lag``.
+    """
+
+    records = []
+    for i in range(window - 1, len(df)):
+        sub = df.iloc[i - window + 1 : i + 1]
+        best_r = np.nan
+        best_lag = 0
+        for lag in range(-max_lag, max_lag + 1):
+            mov = sub['movement_mm'].shift(lag)
+            rain = sub['rainfall_mm']
+            valid = mov.notna() & rain.notna()
+            if valid.sum() < 2:
+                continue
+            r, _ = stats.pearsonr(mov[valid], rain[valid])
+            if np.isnan(best_r) or abs(r) > abs(best_r):
+                best_r = r
+                best_lag = lag
+        records.append(
+            {
+                'timestamp': df['timestamp'].iloc[i],
+                'best_r': float(best_r) if not np.isnan(best_r) else np.nan,
+                'best_lag': int(best_lag),
+            }
+        )
     return pd.DataFrame(records)
 
 
@@ -102,14 +155,23 @@ def analyze_movement_rain_temp(output_dir: Path = Path("analysis_outputs")) -> N
     logger.info("Partial correlations:\n%s", pcorrs)
 
     logger.info("Computing rolling correlation...")
-    rcorr = compute_rolling_correlation(df, window=10)
+    rcorr = compute_rolling_correlation(df, window=14)
+    (output_dir / "rolling_correlation.json").write_text(
+        rcorr.to_json(orient="split", date_format="iso")
+    )
     first_date = first_significant_date(rcorr, r_thresh=0.4)
+
+    logger.info("Computing dynamic lag correlation...")
+    dlag = compute_dynamic_lag_correlation(df, window=30, max_lag=14)
+    (output_dir / "dynamic_lag_correlation.json").write_text(
+        dlag.to_json(orient="split", date_format="iso")
+    )
     if not rcorr.empty:
         plt.plot(rcorr['timestamp'], rcorr['r'])
         plt.axhline(0, color='black', linewidth=0.5)
         plt.xlabel('Date')
         plt.ylabel('Rolling Pearson r')
-        plt.title('Rolling 10-day correlation')
+        plt.title('Rolling 14-day correlation')
         plt.xticks(rotation=45)
         plt.tight_layout()
         plt.savefig(output_dir / 'rolling_correlation.png')
@@ -128,10 +190,14 @@ def analyze_movement_rain_temp(output_dir: Path = Path("analysis_outputs")) -> N
             "temperature_vs_movement_given_rain": pcorrs.iloc[1].to_dict(),
         },
         "rolling_correlation": {
-            "window_days": 10,
+            "window_days": 14,
             "threshold_r": 0.4,
             "threshold_p": 0.05,
             "first_significant_date": first_date.strftime('%Y-%m-%d') if first_date is not None else None,
+        },
+        "dynamic_lag_correlation": {
+            "window_days": 30,
+            "max_lag_days": 14,
         },
     }
     with open(output_dir / "summary.json", "w") as f:

--- a/app.py
+++ b/app.py
@@ -1221,6 +1221,28 @@ async def correlation_summary():
         data = json.load(f)
     return JSONResponse(data)
 
+
+@app.get("/rolling-correlation-data")
+async def rolling_correlation_data():
+    """Return rolling correlation data as JSON."""
+    data_file = ANALYSIS_OUTPUT_DIR / "rolling_correlation.json"
+    if not data_file.exists():
+        raise HTTPException(status_code=404, detail="Rolling correlation data not available")
+    with data_file.open() as f:
+        data = json.load(f)
+    return JSONResponse(data)
+
+
+@app.get("/dynamic-lag-correlation-data")
+async def dynamic_lag_correlation_data():
+    """Return dynamic lag correlation data as JSON."""
+    data_file = ANALYSIS_OUTPUT_DIR / "dynamic_lag_correlation.json"
+    if not data_file.exists():
+        raise HTTPException(status_code=404, detail="Dynamic lag correlation data not available")
+    with data_file.open() as f:
+        data = json.load(f)
+    return JSONResponse(data)
+
 @app.post("/analyse/seasonal")
 async def seasonal_analysis(data: dict):
     """Perform seasonal analysis on the stored data"""

--- a/templates/correlation.html
+++ b/templates/correlation.html
@@ -52,14 +52,19 @@
     </div>
             <div>
                 <h2 class="text-xl font-semibold mb-2">Rolling Correlation Onset Detection</h2>
-                <img src="/analysis_outputs/rolling_correlation.png" alt="Rolling correlation" class="mx-auto border rounded shadow mb-4">
+                <div id="rolling-correlation" class="mx-auto border rounded shadow mb-4" style="height:400px;"></div>
                 <p class="text-gray-700 mb-2">A rolling Pearson correlation is computed between de-seasonalized movement and the 7-day cumulative rainfall series. When the correlation magnitude first exceeds a chosen threshold and is statistically significant, the corresponding date indicates when movement starts responding to rainfall.</p>
                 <ol class="list-decimal list-inside text-gray-700 space-y-1">
                     <li>Align both series on a daily index without gaps.</li>
-                    <li>Compute the 10-day rolling correlation and its p-value.</li>
+                    <li>Compute the 14-day rolling correlation and its p-value.</li>
                     <li>Locate the earliest window where |r| ≥ 0.4 and p &lt; 0.05 (optionally requiring persistence).</li>
                 </ol>
                 <p class="text-gray-700 mt-2">Detected onset date: <span id="detected-date">Loading...</span></p>
+            </div>
+            <div>
+                <h2 class="text-xl font-semibold mb-2">Dynamic Lag Analysis</h2>
+                <div id="dynamic-lag-correlation" class="mx-auto border rounded shadow mb-4" style="height:400px;"></div>
+                <p class="text-gray-700 mb-2">A 30-day window slides across the series and tests lags up to ±14 days. The lag producing the strongest correlation is tracked over time.</p>
             </div>
         </div>
     </div>
@@ -101,6 +106,46 @@
                         {label: 'Temperature', values: rows.map(r => r[idxTemp])}
                     ];
                     Plotly.newPlot('scatter-matrix', [{type: 'splom', dimensions, marker: {size: 5}}], {title: 'Scatter Matrix'});
+                });
+
+            // Load rolling correlation data for interactive plot
+            axios.get('/rolling-correlation-data')
+                .then(res => {
+                    const data = res.data;
+                    const cols = data.columns;
+                    const rows = data.data;
+                    const idxTime = cols.indexOf('timestamp');
+                    const idxR = cols.indexOf('r');
+                    const times = rows.map(r => r[idxTime]);
+                    const rvalues = rows.map(r => r[idxR]);
+                    Plotly.newPlot('rolling-correlation', [{ x: times, y: rvalues, mode: 'lines', name: 'r' }], {
+                        title: 'Rolling 14-day Correlation',
+                        xaxis: { title: 'Date' },
+                        yaxis: { title: 'Pearson r' }
+                    });
+                });
+
+            // Load dynamic lag correlation data
+            axios.get('/dynamic-lag-correlation-data')
+                .then(res => {
+                    const data = res.data;
+                    const cols = data.columns;
+                    const rows = data.data;
+                    const idxTime = cols.indexOf('timestamp');
+                    const idxLag = cols.indexOf('best_lag');
+                    const idxR = cols.indexOf('best_r');
+                    const times = rows.map(r => r[idxTime]);
+                    const lags = rows.map(r => r[idxLag]);
+                    const rvalues = rows.map(r => r[idxR]);
+                    Plotly.newPlot('dynamic-lag-correlation', [
+                        { x: times, y: lags, mode: 'lines', name: 'Best Lag (days)', yaxis: 'y1' },
+                        { x: times, y: rvalues, mode: 'lines', name: 'Correlation', yaxis: 'y2' }
+                    ], {
+                        title: 'Dynamic Lag Analysis',
+                        xaxis: { title: 'Date' },
+                        yaxis: { title: 'Best Lag (days)' },
+                        yaxis2: { title: 'Correlation', overlaying: 'y', side: 'right' }
+                    });
                 });
 
         });


### PR DESCRIPTION
## Summary
- compute best correlation lag in sliding windows
- include dynamic lag time series data in analysis output
- expose `/dynamic-lag-correlation-data` endpoint
- plot dynamic lag analysis interactively

## Testing
- `python -m py_compile analysis.py app.py`
