### PR TITLE
Add user-specific correlation analysis

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -10,7 +10,6 @@ import statsmodels.api as sm
 from pingouin import partial_corr
 import matplotlib.pyplot as plt
 
-from data_loader import load_monitoring_data, load_rainfall_data, load_temperature_data
 
 logger = logging.getLogger(__name__)
 
@@ -371,23 +370,23 @@ def compute_hmm_regime(
     return onset
 
 
-def analyze_movement_rain_temp(output_dir: Path = Path("analysis_outputs")) -> None:
+def analyze_movement_rain_temp(
+    df: pd.DataFrame, output_dir: Path = Path("analysis_outputs")
+) -> None:
     """Run three-way analysis of movement, rainfall and temperature.
 
     Parameters
     ----------
+    df : pd.DataFrame
+        Merged dataframe containing ``timestamp``, ``movement_mm``, ``rainfall_mm``
+        and ``temperature_C`` columns already aligned on a daily frequency.
     output_dir : Path, optional
         Directory where result plots will be written. Created if it does not
         already exist.
     """
     output_dir.mkdir(exist_ok=True, parents=True)
-    logger.info("Loading data...")
-    df_mov = load_monitoring_data()
-    df_rain = load_rainfall_data()
-    df_temp = load_temperature_data()
 
-    logger.info("Merging and resampling data...")
-    df = merge_and_resample([df_mov, df_rain, df_temp])
+    logger.debug("Beginning correlation analysis with %d records", len(df))
 
     # Save merged data for interactive plotting
     (output_dir / "merged_data.json").write_text(

--- a/templates/correlation.html
+++ b/templates/correlation.html
@@ -42,17 +42,17 @@
     </div>
     <div>
         <h2 class="text-xl font-semibold mb-2">Rainfall Cross-Correlation</h2>
-        <img src="/analysis_outputs/rainfall_ccf.png" alt="Rainfall cross correlation" class="mx-auto border rounded shadow" style="max-height: 400px;">
+        <img id="rainfall-ccf" alt="Rainfall cross correlation" class="mx-auto border rounded shadow" style="max-height: 400px;">
         <p class="text-gray-700 mt-2">Bars show how well rainfall aligns with later movement. A prominent positive bar at a specific lag means movement tends to follow rainfall after that many days.</p>
     </div>
     <div>
         <h2 class="text-xl font-semibold mb-2">Temperature Cross-Correlation</h2>
-        <img src="/analysis_outputs/temperature_ccf.png" alt="Temperature cross correlation" class="mx-auto border rounded shadow" style="max-height: 400px;">
+        <img id="temperature-ccf" alt="Temperature cross correlation" class="mx-auto border rounded shadow" style="max-height: 400px;">
         <p class="text-gray-700 mt-2">The bars reveal whether changes in temperature precede or lag behind movement. Peaks near zero lag indicate a near-immediate relationship.</p>
     </div>
             <div>
                 <h2 class="text-xl font-semibold mb-2">Rolling Correlation Onset Detection</h2>
-                <img src="/analysis_outputs/rolling_correlation.png" alt="Rolling correlation" class="mx-auto border rounded shadow mb-4">
+                <img id="rolling-correlation" alt="Rolling correlation" class="mx-auto border rounded shadow mb-4">
                 <p class="text-gray-700 mb-2">A rolling Pearson correlation is computed between de-seasonalized movement and the 7-day cumulative rainfall series. When the correlation magnitude first exceeds a chosen threshold and is statistically significant, the corresponding date indicates when movement starts responding to rainfall.</p>
                 <ol class="list-decimal list-inside text-gray-700 space-y-1">
                     <li>Align both series on a daily index without gaps.</li>
@@ -64,43 +64,43 @@
 
             <div>
                 <h2 class="text-xl font-semibold mb-2">Time-Varying Cross-Correlation Peaks</h2>
-                <img src="/analysis_outputs/tvccf_peaks.png" alt="Time-varying CCF peaks" class="mx-auto border rounded shadow" style="max-height: 400px;">
+                <img id="tvccf-peaks" alt="Time-varying CCF peaks" class="mx-auto border rounded shadow" style="max-height: 400px;">
                 <p class="text-gray-700 mt-2">This plot tracks the lag with the highest absolute cross-correlation in a sliding window. A jump in the peak value—or a shift away from lag&nbsp;0—suggests rainfall starts influencing movement with a delay.</p>
             </div>
 
             <div>
                 <h2 class="text-xl font-semibold mb-2">Sliding-Window Granger Causality</h2>
-                <img src="/analysis_outputs/granger_causality.png" alt="Granger causality" class="mx-auto border rounded shadow" style="max-height: 400px;">
+                <img id="granger-causality" alt="Granger causality" class="mx-auto border rounded shadow" style="max-height: 400px;">
                 <p class="text-gray-700 mt-2">P-values from repeated Granger tests (rainfall→movement) are shown over time. When they first fall below 0.05, rainfall begins to predict future movement.</p>
             </div>
 
             <div>
                 <h2 class="text-xl font-semibold mb-2">Correlation Change-Point Detection</h2>
-                <img src="/analysis_outputs/correlation_change_points.png" alt="Correlation change points" class="mx-auto border rounded shadow" style="max-height: 400px;">
+                <img id="correlation-change-points" alt="Correlation change points" class="mx-auto border rounded shadow" style="max-height: 400px;">
                 <p class="text-gray-700 mt-2">Daily correlations are fed to a change-point algorithm. The red line marks when the correlation regime shifts from weak to strong.</p>
             </div>
 
             <div>
                 <h2 class="text-xl font-semibold mb-2">Wavelet Coherence Analysis</h2>
-                <img src="/analysis_outputs/wavelet_coherence.png" alt="Wavelet coherence" class="mx-auto border rounded shadow" style="max-height: 400px;">
+                <img id="wavelet-coherence" alt="Wavelet coherence" class="mx-auto border rounded shadow" style="max-height: 400px;">
                 <p class="text-gray-700 mt-2">A time–frequency map reveals when rainfall and movement become coherent. Look for the first bright patch exceeding the significance threshold.</p>
             </div>
 
             <div>
                 <h2 class="text-xl font-semibold mb-2">Time-Varying Parameter Regression</h2>
-                <img src="/analysis_outputs/tvp_regression.png" alt="Time-varying regression" class="mx-auto border rounded shadow" style="max-height: 400px;">
+                <img id="tvp-regression" alt="Time-varying regression" class="mx-auto border rounded shadow" style="max-height: 400px;">
                 <p class="text-gray-700 mt-2">The rainfall coefficient from a rolling regression is plotted over time. Sustained positive values indicate rainfall begins contributing to movement.</p>
             </div>
 
             <div>
                 <h2 class="text-xl font-semibold mb-2">Mutual Information Sliding Window</h2>
-                <img src="/analysis_outputs/mutual_information.png" alt="Mutual information" class="mx-auto border rounded shadow" style="max-height: 400px;">
+                <img id="mutual-information" alt="Mutual information" class="mx-auto border rounded shadow" style="max-height: 400px;">
                 <p class="text-gray-700 mt-2">Mutual information captures any dependence, even nonlinear. The first window where MI rises above its threshold points to coupling onset.</p>
             </div>
 
             <div>
                 <h2 class="text-xl font-semibold mb-2">Hidden Markov Model Regime Detection</h2>
-                <img src="/analysis_outputs/hmm_states.png" alt="HMM regimes" class="mx-auto border rounded shadow" style="max-height: 400px;">
+                <img id="hmm-states" alt="HMM regimes" class="mx-auto border rounded shadow" style="max-height: 400px;">
                 <p class="text-gray-700 mt-2">A two-state HMM classifies periods of weak vs strong coupling. The transition into the high-coupling state marks the onset date.</p>
             </div>
         </div>
@@ -118,7 +118,11 @@
                 });
             }
 
-            axios.get('/correlation-summary')
+            const params = new URLSearchParams(window.location.search);
+            const fileId = params.get('file_id');
+            const basePath = fileId ? `/analysis_outputs/file_${fileId}` : '/analysis_outputs';
+
+            axios.get(`/correlation-summary${fileId ? `?file_id=${fileId}` : ''}`)
                 .then(res => {
                     document.getElementById('summary-content').textContent = JSON.stringify(res.data, null, 2);
                     document.getElementById('detected-date').textContent = res.data.rolling_correlation.first_significant_date || 'None';
@@ -129,7 +133,7 @@
                 });
 
             // Load merged data for scatter matrix
-            axios.get('/analysis_outputs/merged_data.json')
+            axios.get(`${basePath}/merged_data.json`)
                 .then(res => {
                     const data = res.data;
                     const cols = data.columns;
@@ -144,6 +148,17 @@
                     ];
                     Plotly.newPlot('scatter-matrix', [{type: 'splom', dimensions, marker: {size: 5}}], {title: 'Scatter Matrix'});
                 });
+
+            document.getElementById('rainfall-ccf').src = `${basePath}/rainfall_ccf.png`;
+            document.getElementById('temperature-ccf').src = `${basePath}/temperature_ccf.png`;
+            document.getElementById('rolling-correlation').src = `${basePath}/rolling_correlation.png`;
+            document.getElementById('tvccf-peaks').src = `${basePath}/tvccf_peaks.png`;
+            document.getElementById('granger-causality').src = `${basePath}/granger_causality.png`;
+            document.getElementById('correlation-change-points').src = `${basePath}/correlation_change_points.png`;
+            document.getElementById('wavelet-coherence').src = `${basePath}/wavelet_coherence.png`;
+            document.getElementById('tvp-regression').src = `${basePath}/tvp_regression.png`;
+            document.getElementById('mutual-information').src = `${basePath}/mutual_information.png`;
+            document.getElementById('hmm-states').src = `${basePath}/hmm_states.png`;
 
         });
     </script>


### PR DESCRIPTION
## Summary
- refactor `analyze_movement_rain_temp` to accept a pre-merged DataFrame
- generate example data on startup and pass to refactored analysis
- create `/run-correlation` endpoint for running analysis on uploaded files
- parameterise `/correlation-summary` with a `file_id`
- update correlation page to load results from a file-specific directory

## Testing
- `python -m py_compile analysis.py app.py`